### PR TITLE
run cron only if letsencrypt is enabled

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -124,10 +124,8 @@ fi
 nginx -g 'daemon off;' & sleep 5
 
 if [ "$ENABLE_LETSENCRYPT" = True ] && [ "$DOMAIN_NAME" ] && [ "$USER_EMAIL" ]; then
-
-fullchain_path="/var/log/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem"
-
-certbot certonly -n --webroot --webroot-path /usr/share/nginx/html --no-redirect --agree-tos --email "$USER_EMAIL" -d "$DOMAIN_NAME" --config-dir /var/log/letsencrypt/ --work-dir /var/log/letsencrypt/work --logs-dir /var/log/letsencrypt/log 
+ fullchain_path="/var/log/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem"
+  certbot certonly -n --webroot --webroot-path /usr/share/nginx/html --no-redirect --agree-tos --email "$USER_EMAIL" -d "$DOMAIN_NAME" --config-dir /var/log/letsencrypt/ --work-dir /var/log/letsencrypt/work --logs-dir /var/log/letsencrypt/log 
 
   if [ $? -eq 0 ]; then
 
@@ -145,8 +143,9 @@ certbot certonly -n --webroot --webroot-path /usr/share/nginx/html --no-redirect
   else
     echo "Failed to obtain Let's Encrypt certificate."
   fi
+
+  crond -b -l 5
 fi
 
-crond -b -l 5
 
 tail -f /dev/null


### PR DESCRIPTION
I believe that `crond` should be optional and started only when letsencrypt is enabled.

I found out that my instance is reporting 
```
speedtest-6cfc9bf9b6-gbpjc speedtest /entrypoint.sh: line 150: crond: Operation not permitted
```

so it may be broken even when le is enabled, just FYI.