### PR TITLE
Removing unnecessary use of EXPOSE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,6 @@ RUN chown -R nginx:nginx /etc/crontabs/nginx
 
 USER ${SET_USER}
 
-EXPOSE ${HTTP_PORT} ${HTTPS_PORT}
-
 STOPSIGNAL SIGQUIT
 
 CMD ["/entrypoint.sh"]


### PR DESCRIPTION
This is in response to the issue: https://github.com/openspeedtest/Docker-Image/issues/22

Using the EXPOSE keyword in the `Dockerfile` forces people to expose both an HTTP port and an HTTPS port even if they don't want both ports. By removing this, it does not break any support for the normal expected use as described in this projects documentation of supplying the port using the command `docker run -p 3000:8080 ...` or using a docker compose file. 

This fixes the problem when people want to remap some of the ports and not expose all of the ports (for instance only exposing an https port). 

Please consider merging this into main or follow up with any concerns. Thanks!